### PR TITLE
Refactoring scrape.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__/
 .ipynb_checkpoints/
 img/
+urls.csv
+subreddits.txt

--- a/obfuscate.py
+++ b/obfuscate.py
@@ -17,11 +17,11 @@ def get_key():
         return f.read()
 
 
-def stream_to_string(byte_str, key, subreddit, file_number):
+def stream_to_string(byte_str, key, image_id):
     im_str = base64.b64encode(byte_str).decode()
 
     # Add key to string and save as text
-    with open('img/r_{}/{}.enc'.format(subreddit, file_number), 'wb') as f:
+    with open('img/{}.enc'.format(image_id), 'wb') as f:
         f.write((key + im_str).encode())
 
 

--- a/scrape.ipynb
+++ b/scrape.ipynb
@@ -3,30 +3,22 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend.\n"
-     ]
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
     "import praw\n",
-    "import cnn\n",
     "import scrape\n",
     "import obfuscate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 129,
    "metadata": {
-    "collapsed": false
+    "scrolled": false
    },
    "outputs": [
     {
@@ -34,34 +26,52 @@
      "output_type": "stream",
      "text": [
       "Authenticating...\n",
-      "Authenticated as austin_josh_test\n"
+      "Authenticated as austin_josh_test\n",
+      "Scraping 34 subreddits... 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 Done!\n",
+      "Scraped and saved 3,820 urls.\n"
      ]
     }
    ],
    "source": [
-    "urls = scrape.scrape_all()"
+    "urls = scrape.scrape_all(min_score=5000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2,255 (59%) of 3,820 urls are valid.\n"
+     ]
+    }
+   ],
+   "source": [
+    "scrape.validate_urls('urls.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "scrape.clear_img_dir()\n",
-    "scrape.download_images(urls, hide=True)"
+    "scrape.download_images('urls.csv', limit=1000, hide=True)"
    ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python [conda env:neural-net]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-neural-net-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -73,7 +83,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/scrape.ipynb
+++ b/scrape.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 29,
    "metadata": {
     "scrolled": false
    },
@@ -27,8 +27,8 @@
      "text": [
       "Authenticating...\n",
       "Authenticated as austin_josh_test\n",
-      "Scraping 34 subreddits... 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 Done!\n",
-      "Scraped and saved 3,820 urls.\n"
+      "Scraping 1 subreddits for posts with at least 5000 score... 1 Done!\n",
+      "Scraped and saved 999 urls.\n"
      ]
     }
    ],
@@ -38,14 +38,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2,255 (59%) of 3,820 urls are valid.\n"
+      "909 (91%) of 999 urls are valid.\n"
      ]
     }
    ],
@@ -63,6 +63,51 @@
    "source": [
     "scrape.clear_img_dir()\n",
     "scrape.download_images('urls.csv', limit=1000, hide=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unable to read image 450 (HTTP Error).\n",
+      "Unable to read image 848 (Unknown)\n",
+      "Unable to read image 640 (HTTP Error).\n",
+      "Unable to read image 640 (HTTP Error).\n",
+      "Unable to read image 13 (Unknown)\n",
+      "45.8 s ± 3.18 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Can be used in a for loop\n",
+    "for array in scrape.get_images(100):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "353 ms ± 107 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "# Or can be used like this to get the next image array in the list\n",
+    "array_gen = scrape.get_images(100)\n",
+    "type(next(array_gen))"
    ]
   }
  ],

--- a/scrape.py
+++ b/scrape.py
@@ -2,6 +2,9 @@ import os
 import praw
 import re
 import obfuscate
+import requests
+import csv
+import pandas as pd
 from urllib import request, parse, error
 from shutil import rmtree
 import io
@@ -22,7 +25,7 @@ def clear_img_dir():
 
 
 # Tries to save a single image given a URL, subreddit, and file number
-def save_image(url, key, subreddit, file_number, hide=True):
+def save_image(url, key, image_id, hide=True):
     try:
         response = request.urlopen(url)
     except error.HTTPError as err:
@@ -33,58 +36,106 @@ def save_image(url, key, subreddit, file_number, hide=True):
     if hide:
         byte_str = io.BytesIO()
         img_resize.save(byte_str, format='JPEG')
-        obfuscate.stream_to_string(byte_str.getvalue(), key, subreddit, file_number)
+        obfuscate.stream_to_string(byte_str.getvalue(), key, image_id)
     else:
-        img_resize.save('img/r_{}/{}_{}.jpg'.format(subreddit, subreddit, file_number))
+        img_resize.save('img/{}{}'.format(image_id, os.path.splitext(parse.urlparse(url)[2])[1]))
+
+def lookup_url(image_id, filename='urls.csv'):
+    df = pd.read_csv(filename, index_col='image_id')
+    url, subreddit, valid = df.loc[image_id, :]
+    print('{} ({})'.format(url, subreddit))
 
 
-# Downloads the top N images from a subreddit
-def download_images(urls, hide=True):
+def download_images(filename='urls.csv', limit=100, hide=True, randomize=True):
     if not os.path.isfile('.key'):
         obfuscate.gen_key()
     key = obfuscate.get_key()
 
-    for subreddit, sub_urls in urls.items():
-        save_dir = 'img/r_' + subreddit
-        os.makedirs(save_dir, exist_ok=True)
+    # Read data from file and sample rows randomly
+    if randomize:
+        seed = None
+    else:
+        seed = 1
+    df = pd.read_csv(filename, index_col='image_id')
+    df = df.sample(limit, random_state=seed)
 
-        for i, url in enumerate(sub_urls):
-            parsed = list(parse.urlparse(url))
-            # Check to see if URL is already in image file format
-            if re.match('.*\.(?:jpeg|jpg|png|bmp|tiff|gif)$', parsed[2]):
-                save_image(url, key, subreddit, i+1, hide)
-            # Adjust imgur URL format to point to the image file, skipping albums
-            elif 'imgur' in parsed[1]:
+    # Attempt to download all images
+    for image_id, (url, _, _) in df.iterrows():
+        try:
+            save_image(url, key, image_id, hide)
+        except:
+            pass
+
+
+def validate_urls(filename='urls.csv'):
+    # TODO make parsed url a dictionary
+    # TODO check for bad status code before download
+
+    valid_formats = ['jpeg', 'jpg', 'png', 'bmp', 'tiff']
+    df = pd.read_csv(filename, index_col='image_id')
+    df['valid'] = False
+    for image_id, (url, subreddit, _) in df.iterrows():
+        parsed = list(parse.urlparse(url))
+
+        # Check for a file extension
+        extension = os.path.splitext(parsed[2])[1]
+        if extension:
+            # Check for image formats
+            if any(f in parsed[2] for f in valid_formats):
+                df.loc[image_id, 'valid'] = True
+        # Check for imgur links and force them to jpg domain
+        else:
+            if 'imgur' in parsed[1]:
                 if '/a/' in parsed[2]: # skip albums
                     continue
                 parsed[1] = 'i.imgur.com' # force domain to i.imgur.com
                 parsed[2] += '.jpg' # add jpg file extension
                 url = parse.urlunparse(parsed)
-                save_image(url, key, subreddit, i+1, hide)
+                df.loc[image_id, 'url'] = url
+                df.loc[image_id, 'valid'] = True
 
-def scrape_all():
+    # Reset image ids to count from zero
+    validated = df[df['valid']]
+    validated = validated.reset_index(drop=True)
+    validated.index.name = 'image_id'
+
+    num_valid = len(validated)
+    total = len(df)
+    print('{:,} ({:.0%}) of {:,} urls are valid.'.format(num_valid, num_valid/total, total))
+    validated.to_csv('urls.csv')
+
+
+def scrape_all(min_score, filename='urls.csv'):
+
     user_agent = authenticate()
 
-    temp = open('subreddits.txt', 'r')
-    subreddits = temp.readlines()
+    # Get subreddits from file
+    with open('subreddits.txt', 'r') as f:
+        subreddits = f.readlines()
     subreddits = [x.strip() for x in subreddits]
-
-    out_dict = {}
+    num_subs = len(subreddits)
 
     # Loop through all subreddits in the text file
-    for s in subreddits:
-        out_dict[s] = []
+    urls = []
+    print('Scraping {} subreddits for posts with at least {} score...' \
+        .format(num_subs, min_score), end=' ')
+    for i, s in enumerate(subreddits):
+        print(i+1, end=' ')
         subreddit = user_agent.subreddit(s)
 
         # Loop through top posts in the subreddit
-        for submission in subreddit.top(limit=10):
-            # Append URL to dictionary
-            # TODO: Only take URLs from specific sites
-            # TODO: Get direct image from Imgur links
-            # TODO: Get individual pictures from Imgur albums
-            out_dict[s].append(submission.url)
+        submissions = subreddit.top(limit=None)
+        for submission in submissions:
+            # Append URL to dictionary if above threshold
+            if submission.score >= min_score:
+                urls.append([submission.url, s])
+    print('Done!')
 
-    return out_dict
+    df = pd.DataFrame(urls, columns=['subreddit', 'url'])
+    df.index.name = 'image_id'
+    df.to_csv(filename)
+
+    print('Scraped and saved {:,} urls.'.format(len(urls)))
 
 
 if __name__ == '__main__':

--- a/subreddits.txt
+++ b/subreddits.txt
@@ -1,2 +1,0 @@
-pics
-catsstandingup


### PR DESCRIPTION
Refactored scrape.py considerably to make it more modular and change the scraping approach. Now operates with the following steps:

1. `scrape_all` pulls all urls for posts above the desired score threshold in subreddits in subreddits.txt and saves them to csv
2. `validate_urls` checks each url in the csv to see if it is an image file that can be downloaded _(still need to add code to check for imgur redirects and exclude)_ and filters to the validated set
3. `download_images` has been replaced by `get_images` which returns a generator that generates arrays given a requested number of urls

I also removed subreddits.txt from Git tracking so we can test with the actual subreddits of interest.